### PR TITLE
Debugger and Console snippets

### DIFF
--- a/snippets/emberjs.json
+++ b/snippets/emberjs.json
@@ -248,6 +248,14 @@
 		"description": "Component willDestroyElement Hook"
 	},
 
+	"debugger": {
+		"prefix": "dbg",
+		"body": [
+			"window.debugger;"
+		],
+		"description": "window.debugger"
+	},
+
 	// Ember store commands
 	"storeInject": {
 		"prefix": "sinj",

--- a/snippets/emberjs.json
+++ b/snippets/emberjs.json
@@ -10,12 +10,28 @@
 		"description": "console.log(object)"
 	},
 
+	"windowConsoleLog": {
+		"prefix": "wclg",
+		"body": [
+			"window.console.log(${1:object});"
+		],
+		"description": "window.console.log(object)"
+	},
+
 	"consoleLogWithTwoParams": {
 		"prefix": "clg2",
 		"body": [
 			"console.log('${1:tag}', ${2:value});"
 		],
 		"description": "console.log('tag', value)"
+	},
+
+	"windowConsoleLogWithTwoParams": {
+		"prefix": "wclg2",
+		"body": [
+			"window.console.log('${1:tag}', ${2:value});"
+		],
+		"description": "window.console.log('tag', value)"
 	},
 
 	// Get and Set


### PR DESCRIPTION
- The linter often complains about `console.log.` However, it is satisfied with `window.console`. So, I would suggest this change to the `clg `and `clg2` snippets.

- It's very handy to have a snippet for `debugger`, especially with the `window.` prefix.